### PR TITLE
Skip critical on NO TTY case

### DIFF
--- a/gow.go
+++ b/gow.go
@@ -166,7 +166,13 @@ func main() {
 	state before exiting.
 	*/
 	state, err := makeTerminalRaw(syscall.Stdin)
-	critical(err)
+	if err != nil {
+		if err == syscall.ENOTTY {
+			log.Printf("Setting raw terminal mode error: No terminal exists.")
+		} else {
+			critical(err)
+		}
+	}
 	termios = &state
 
 	/**


### PR DESCRIPTION
Hello Nelo.

I compared a few tools, but gow is the best.
However, when I am using it in Docker container I have a problem.
When it run and try to make terminal in raw mode it fails and finish because of critical(err).

	state, err := makeTerminalRaw(syscall.Stdin)
	critical(err)
                    ===========> at this point gow quit with  "[gow] inappropriate ioctl for device" message.
	termios = &state

The root cause is that docker containers may run without terminal.
I think we have a few solutions, 
- just ignore errors on ENOTTY error case.
- a command-line flag to avoid terminal setting operation. 
- catch every signals and forward them to sub-process.

I thought the first one is most easy and made a PR.
Please accept or deny it If you have different idea.

Best regards
Sungkyu Kim
