### PR TITLE
make go compiler binary name configurable

### DIFF
--- a/gow.go
+++ b/gow.go
@@ -25,8 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Consider making configurable?
-const CMD = "go"
+var CMD = "go"
 
 const HELP = `
 "gow" is the missing watch mode for the "go" command.
@@ -56,6 +55,7 @@ Options:
 	-s	Soft-clear terminal, keeping scrollback
 	-e	Extensions to watch, comma-separated; default: "go,mod"
 	-i	Ignored paths, relative to CWD, comma-separated
+	-g  Go compiler binary name
 
 Supported control codes / hotkeys:
 
@@ -101,6 +101,7 @@ var (
 
 func main() {
 	FLAG_SET.Usage = func() {}
+	FLAG_SET.StringVar(&CMD, "g", "go", "")
 	FLAG_SET.Var(&EXTENSIONS, "e", "")
 	FLAG_SET.Var(&IGNORED_PATHS, "i", "")
 


### PR DESCRIPTION
Beta versions of Go compiler are released under a different name, i.e. `go1.16beta1` instead of `go`. I would like to use `gow` with the most recent beta, but there seems to be no way to specify the different `go` binary name. I could, of course, create an alias or a symlink, but I think it would be nice to switch versions dynamically. I have chosen the `g` CLI flag, because `-c` (for "compiler") has been taken. Feel free to change it, of course.