### PR TITLE
Add 1.16+ module-aware install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ Make sure you have Go installed, then run this:
 go get -u github.com/mitranim/gow
 ```
 
+If you're running go 1.16 or later and want to run the command in a folder tree that contains a `go.mod` file, run this instead:
+
+```sh
+go install github.com/mitranim/gow@latest
+```
+
 This will download the source and compile the executable into `$GOPATH/bin/gow`. Make sure `$GOPATH/bin` is in your `$PATH` so the shell can discover the `gow` command. For example, my `~/.profile` contains this:
 
 ```sh


### PR DESCRIPTION
go 1.16 subtly changes the way that the go command works when installing binaries inside modules when the module-aware mode is on. `install` lets you install binary tools without adding spurious dependencies to the go.mod file, but barfs if you don't explicitly add a `@version`.