### PR TITLE
Optimized shouldRestart()

### DIFF
--- a/gow.go
+++ b/gow.go
@@ -504,25 +504,10 @@ func allowByIgnoredPaths(absPath string) (bool, error) {
 	return true, nil
 }
 
-var pathSepStr = string(filepath.Separator)
-
 // Assumes both paths are relative or both are absolute. Doesn't care to support
 // scheme-qualified paths such as network paths.
 func hasBasePath(longerPath string, basePath string) bool {
-	longer := strings.Split(filepath.Clean(longerPath), pathSepStr)
-	base := strings.Split(filepath.Clean(basePath), pathSepStr)
-
-	if len(base) > len(longer) {
-		return false
-	}
-
-	for i := 0; i < len(base); i++ {
-		if base[i] != longer[i] {
-			return false
-		}
-	}
-
-	return true
+	return strings.HasPrefix(longerPath, basePath)
 }
 
 func allowByExtensions(path string) bool {
@@ -605,8 +590,12 @@ func decorateExtension(val string) string {
 }
 
 func decorateIgnore(val string) string {
-	cwd, _ := os.Getwd()
-	return filepath.Join(cwd, val)
+	if !filepath.IsAbs(val) {
+		cwd, _ := os.Getwd()
+		val = filepath.Join(cwd, val)
+	}
+
+	return filepath.Clean(val)
 }
 
 var pathRegexp = regexp.MustCompile(`^[\w. /\\-]+$`)

--- a/gow_test.go
+++ b/gow_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"github.com/rjeczalik/notify"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type TestFsEvent struct {
+	path string
+}
+
+func (e *TestFsEvent) Event() notify.Event {
+	return 0
+}
+
+func (e *TestFsEvent) Path() string {
+	return e.path
+}
+
+func (e *TestFsEvent) Sys() interface{} {
+	return nil
+}
+
+func BenchmarkShouldRestart(b *testing.B) {
+	EXTENSIONS = &flagStrings{validateExtension, decorateExtension, []string{"ext1", "ext2", "ext3"}}
+	IGNORED_PATHS = &flagStrings{validatePath, decorateIgnore, []string{"./ignore1", "ignore2", "ignore3"}}
+
+	cwd, _ := os.Getwd()
+	event := &TestFsEvent{path: filepath.Join(cwd, "ignore3/file.ext3")}
+
+	for i := 0; i < b.N; i++ {
+		_, _ = shouldRestart(event)
+	}
+}
+
+func TestShouldRestart(t *testing.T) {
+
+	type shouldRestartCase struct {
+		path       string
+		ignore     []string
+		extensions []string
+		expected   bool
+	}
+
+	cases := []shouldRestartCase{
+		{path: "file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
+		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
+		{path: "to/file", extensions: []string{"go"}, ignore: []string{}, expected: false},
+		{path: "to/file.txt", extensions: []string{"go"}, ignore: []string{}, expected: false},
+		{path: "to/file.go.txt", extensions: []string{"go"}, ignore: []string{}, expected: false},
+		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"to"}, expected: false},
+		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"yo", "to"}, expected: false},
+		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"yo", "./to/"}, expected: false},
+		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"file"}, expected: true},
+		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
+		{path: ".hidden/file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
+		{path: ".hidden/ignore/file.go", extensions: []string{"go"}, ignore: []string{".hidden/ignore"}, expected: false},
+		{path: ".hidden/no/file.go", extensions: []string{"go"}, ignore: []string{".hidden/ignore"}, expected: true},
+	}
+
+	cwd, _ := os.Getwd()
+
+	for _, testCase := range cases {
+		EXTENSIONS = &flagStrings{validateExtension, decorateExtension, testCase.extensions}
+		IGNORED_PATHS = &flagStrings{validatePath, decorateIgnore, testCase.ignore}
+
+		EXTENSIONS.Prepare()
+		IGNORED_PATHS.Prepare()
+
+		should, _ := shouldRestart(&TestFsEvent{path: filepath.Join(cwd, testCase.path)})
+
+		if testCase.expected != should {
+			t.Error(testCase.expected, should, testCase)
+		}
+	}
+}

--- a/gow_test.go
+++ b/gow_test.go
@@ -27,11 +27,17 @@ func BenchmarkShouldRestart(b *testing.B) {
 	EXTENSIONS = &flagStrings{validateExtension, decorateExtension, []string{"ext1", "ext2", "ext3"}}
 	IGNORED_PATHS = &flagStrings{validatePath, decorateIgnore, []string{"./ignore1", "ignore2", "ignore3"}}
 
+	EXTENSIONS.Prepare()
+	IGNORED_PATHS.Prepare()
+
 	cwd, _ := os.Getwd()
 	event := &TestFsEvent{path: filepath.Join(cwd, "ignore3/file.ext3")}
 
 	for i := 0; i < b.N; i++ {
-		_, _ = shouldRestart(event)
+		s, _ := shouldRestart(event)
+		if s {
+			b.Fatal("shouldRestart() is broken")
+		}
 	}
 }
 
@@ -45,19 +51,19 @@ func TestShouldRestart(t *testing.T) {
 	}
 
 	cases := []shouldRestartCase{
-		{path: "file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
-		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
-		{path: "to/file", extensions: []string{"go"}, ignore: []string{}, expected: false},
-		{path: "to/file.txt", extensions: []string{"go"}, ignore: []string{}, expected: false},
-		{path: "to/file.go.txt", extensions: []string{"go"}, ignore: []string{}, expected: false},
-		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"to"}, expected: false},
-		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"yo", "to"}, expected: false},
-		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"yo", "./to/"}, expected: false},
-		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{"file"}, expected: true},
-		{path: "to/file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
-		{path: ".hidden/file.go", extensions: []string{"go"}, ignore: []string{}, expected: true},
-		{path: ".hidden/ignore/file.go", extensions: []string{"go"}, ignore: []string{".hidden/ignore"}, expected: false},
-		{path: ".hidden/no/file.go", extensions: []string{"go"}, ignore: []string{".hidden/ignore"}, expected: true},
+		{path: "file.go", extensions: []string{"mod", "go"}, ignore: []string{}, expected: true},
+		{path: "to/file.go", extensions: []string{"mod", "go"}, ignore: []string{}, expected: true},
+		{path: "to/file", extensions: []string{"mod", "go"}, ignore: []string{}, expected: false},
+		{path: "to/file.txt", extensions: []string{"mod", "go"}, ignore: []string{}, expected: false},
+		{path: "to/file.go.txt", extensions: []string{"mod", "go"}, ignore: []string{}, expected: false},
+		{path: "to/file.go", extensions: []string{"mod", "go"}, ignore: []string{"to"}, expected: false},
+		{path: "to/file.go", extensions: []string{"mod", "go"}, ignore: []string{"yo", "to"}, expected: false},
+		{path: "to/file.go", extensions: []string{"mod", "go"}, ignore: []string{"yo", "./to/"}, expected: false},
+		{path: "to/file.go", extensions: []string{"mod", "go"}, ignore: []string{"file"}, expected: true},
+		{path: "to/file.go", extensions: []string{"mod", "go"}, ignore: []string{}, expected: true},
+		{path: ".hidden/file.go", extensions: []string{"mod", "go"}, ignore: []string{}, expected: true},
+		{path: ".hidden/ignore/file.go", extensions: []string{"mod", "go"}, ignore: []string{".hidden/ignore"}, expected: false},
+		{path: ".hidden/no/file.go", extensions: []string{"mod", "go"}, ignore: []string{".hidden/ignore"}, expected: true},
 	}
 
 	cwd, _ := os.Getwd()


### PR DESCRIPTION
> I add some tests and benchmark method

---

As for me, **shouldRestart()** is very important method, because it checks EVERY fs event, so its speed have to be the best.

How was before optimization:
```
goos: linux
goarch: amd64
pkg: github.com/mitranim/gow
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
BenchmarkShouldRestart
BenchmarkShouldRestart-8       449582        2632 ns/op
PASS
```

~~How is now~~:
```
goos: linux
goarch: amd64
pkg: github.com/mitranim/gow
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
BenchmarkShouldRestart
BenchmarkShouldRestart-8      1455654         807.0 ns/op
PASS
```

Updated results:
```
goos: linux
goarch: amd64
pkg: github.com/mitranim/gow
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
BenchmarkShouldRestart
BenchmarkShouldRestart-8   	68644002	        16.76 ns/op
```

---

The main thing about optimization:
- in old version, every time `os.Getwd()` and `filepath.Join()` where called
- in new version, these methods called only once on init of gow
