### PR TITLE
bump notify version to handle mac API deprecation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.18
 
 require (
 	github.com/mitranim/gg v0.0.13
-	github.com/rjeczalik/notify v0.9.2
+	github.com/rjeczalik/notify v0.9.3
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678
 )


### PR DESCRIPTION
see https://github.com/rjeczalik/notify/issues/212

generates a nasty-looking error on install at the moment:

```
# github.com/rjeczalik/notify
cgo-gcc-prolog:217:2: warning: 'FSEventStreamScheduleWithRunLoop' is deprecated: first deprecated in macOS 13.0 - Use FSEventStreamSetDispatchQueue instead. [-Wdeprecated-declarations]
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/FSEvents.framework/Headers/FSEvents.h:1138:1: note: 'FSEventStreamScheduleWithRunLoop' has been explicitly marked deprecated here
```