### PR TITLE
Print hotkey help on ^H

### DIFF
--- a/gow_misc.go
+++ b/gow_misc.go
@@ -15,18 +15,31 @@ const (
 	// These names reflect standard naming and meaning.
 	// Reference: https://en.wikipedia.org/wiki/Ascii.
 	// See our re-interpretation below.
-	ASCII_END_OF_TEXT      = 3  // ^C
-	ASCII_FILE_SEPARATOR   = 28 // ^\
-	ASCII_DEVICE_CONTROL_2 = 18 // ^R
-	ASCII_DEVICE_CONTROL_4 = 20 // ^T
-	ASCII_UNIT_SEPARATOR   = 31 // ^- or ^?
+	ASCII_END_OF_TEXT      = 3   // ^C
+	ASCII_BACKSPACE        = 8   // ^H
+	ASCII_FILE_SEPARATOR   = 28  // ^\
+	ASCII_DEVICE_CONTROL_2 = 18  // ^R
+	ASCII_DEVICE_CONTROL_4 = 20  // ^T
+	ASCII_UNIT_SEPARATOR   = 31  // ^- or ^?
+	ASCII_DELETE           = 127 // ^H on macOS
 
 	// These names reflect our re-interpretation of standard codes.
-	CODE_INTERRUPT     = ASCII_END_OF_TEXT
-	CODE_QUIT          = ASCII_FILE_SEPARATOR
-	CODE_RESTART       = ASCII_DEVICE_CONTROL_2
-	CODE_STOP          = ASCII_DEVICE_CONTROL_4
-	CODE_PRINT_COMMAND = ASCII_UNIT_SEPARATOR
+	CODE_INTERRUPT        = ASCII_END_OF_TEXT
+	CODE_QUIT             = ASCII_FILE_SEPARATOR
+	CODE_RESTART          = ASCII_DEVICE_CONTROL_2
+	CODE_STOP             = ASCII_DEVICE_CONTROL_4
+	CODE_PRINT_COMMAND    = ASCII_UNIT_SEPARATOR
+	CODE_PRINT_HELP       = ASCII_BACKSPACE
+	CODE_PRINT_HELP_MACOS = ASCII_DELETE
+
+	hotkeyHelp = `	3     ^C          Kill subprocess with SIGINT. Repeat within 1s to kill gow.
+	18    ^R          Kill subprocess with SIGTERM, restart.
+	20    ^T          Kill subprocess with SIGTERM. Repeat within 1s to kill gow.
+	28    ^\          Kill subprocess with SIGQUIT. Repeat within 1s to kill gow.
+	31    ^- or ^?    Print currently running command.
+	8     ^H	  Print this help
+	127   ^H (macOS)  Print this help
+`
 )
 
 var (

--- a/gow_opt.go
+++ b/gow_opt.go
@@ -80,12 +80,8 @@ Some also support comma-separated parsing.
 
 Control codes / hotkeys:
 
-	3     ^C          Kill subprocess with SIGINT. Repeat within 1s to kill gow.
-	18    ^R          Kill subprocess with SIGTERM, restart.
-	20    ^T          Kill subprocess with SIGTERM. Repeat within 1s to kill gow.
-	28    ^\          Kill subprocess with SIGQUIT. Repeat within 1s to kill gow.
-	31    ^- or ^?    Print currently running command.
-`, gg.FlagHelp[Opt]()))
+%s
+`, gg.FlagHelp[Opt](), hotkeyHelp))
 }
 
 func (self Opt) LogErr(err error) {

--- a/gow_stdio.go
+++ b/gow_stdio.go
@@ -80,6 +80,11 @@ func (self *Stdio) OnByte(char byte) {
 	case CODE_STOP:
 		self.OnCodeStop()
 
+	case CODE_PRINT_HELP:
+		fallthrough
+	case CODE_PRINT_HELP_MACOS:
+		self.OnCodePrintHelp()
+
 	default:
 		self.OnByteAny(char)
 	}
@@ -100,6 +105,10 @@ func (self *Stdio) OnCodeQuit() {
 
 func (self *Stdio) OnCodePrintCommand() {
 	log.Printf(`current command: %q`, os.Args)
+}
+
+func (self *Stdio) OnCodePrintHelp() {
+	log.Printf(hotkeyHelp)
 }
 
 func (self *Stdio) OnCodeRestart() {


### PR DESCRIPTION
This adds a hotkey ^H to show the hotkey help while running. Both Windows Terminal and the integrated terminal in VS Code send 0x08 (ASCII Backspace) on ^H, while you reported in https://github.com/mitranim/gow/issues/34#issuecomment-1695621676 that on your macOS machine it sends 0x71 (127, ASCII_DELETE), so I implemented this to support either.

I'm not sure if you're a fan of the deduplication of the help text, or if we should somehow generate the text from the implemented features, so if you have opinions on that I'm very open to suggestions.

Lastly, thanks a lot for the help with how to figure out the details on how to implement this!

Fixes #34.