### PR TITLE
support Windows builds (#6)

### DIFF
--- a/gow_cmd.go
+++ b/gow_cmd.go
@@ -88,7 +88,7 @@ func (self *Cmd) Broadcast(sig syscall.Signal) {
 
 	if !verb {
 		for _, pid := range pids {
-			gg.Nop1(syscall.Kill(pid, sig))
+			gg.Nop1(signalProc(pid, sig))
 			return
 		}
 	}
@@ -98,7 +98,7 @@ func (self *Cmd) Broadcast(sig syscall.Signal) {
 	var errs []error
 
 	for _, pid := range pids {
-		err := syscall.Kill(pid, sig)
+		err := signalProc(pid, sig)
 		if err != nil {
 			unsent = append(unsent, pid)
 			errs = append(errs, err)

--- a/gow_const_linux.go
+++ b/gow_const_linux.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || dragonfly || freebsd || netbsd || openbsd)
+//go:build !(darwin || dragonfly || freebsd || netbsd || openbsd || windows)
 
 package main
 

--- a/gow_main.go
+++ b/gow_main.go
@@ -169,7 +169,7 @@ func (self *Main) kill(sig syscall.Signal) {
 	should not be received because after calling this method, we also return
 	from the main function.
 	*/
-	gg.Nop1(syscall.Kill(os.Getpid(), sig))
+	gg.Nop1(signalSelf(sig))
 }
 
 func (self *Main) GetEchoMode() EchoMode {

--- a/gow_misc.go
+++ b/gow_misc.go
@@ -33,6 +33,36 @@ const (
 	CODE_PRINT_HELP_MACOS = ASCII_DELETE
 )
 
+// https://en.wikipedia.org/wiki/ANSI_escape_code
+const (
+	// Standard terminal escape sequence. Same as "\x1b" or "\033".
+	TermEsc = string(rune(27))
+
+	// Control Sequence Introducer. Used for other codes.
+	TermEscCsi = TermEsc + `[`
+
+	// Update cursor position to first row, first column.
+	TermEscCup = TermEscCsi + `1;1H`
+
+	// Supposed to clear the screen without clearing the scrollback, aka soft
+	// clear. Seems insufficient on its own, at least in some terminals.
+	TermEscErase2 = TermEscCsi + `2J`
+
+	// Supposed to clear the screen and the scrollback, aka hard clear. Seems
+	// insufficient on its own, at least in some terminals.
+	TermEscErase3 = TermEscCsi + `3J`
+
+	// Supposed to reset the terminal to initial state, aka super hard clear.
+	// Seems insufficient on its own, at least in some terminals.
+	TermEscReset = TermEsc + `c`
+
+	// Clear screen without clearing scrollback.
+	TermEscClearSoft = TermEscCup + TermEscErase2
+
+	// Clear screen AND scrollback.
+	TermEscClearHard = TermEscCup + TermEscReset + TermEscErase3
+)
+
 const HOTKEY_HELP = `Control codes / hotkeys:
 
 	3     ^C          Kill subprocess with SIGINT. Repeat within 1s to kill gow.
@@ -45,8 +75,6 @@ const HOTKEY_HELP = `Control codes / hotkeys:
 
 var (
 	NEWLINE      = "\n"
-	FD_TERM      = syscall.Stdin
-	KILL_SIGS    = []syscall.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM}
 	KILL_SIGS_OS = gg.Map(KILL_SIGS, toOsSignal[syscall.Signal])
 	KILL_SIG_SET = gg.SetOf(KILL_SIGS...)
 	RE_WORD      = regexp.MustCompile(`^\w+$`)

--- a/gow_ps_bsd.go
+++ b/gow_ps_bsd.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || linux)
+//go:build !(darwin || linux || windows)
 
 package main
 

--- a/gow_ps_windows.go
+++ b/gow_ps_windows.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"unsafe"
+
+	"github.com/mitranim/gg"
+	"golang.org/x/sys/windows"
+)
+
+/*
+Windows has no `/proc` and no portable `ps` (the binary that ships with Git
+Bash reports MSYS pids, not native Windows pids, so it cannot be matched
+against pids from `os.Getpid` or `exec.Cmd.Process.Pid`).
+
+Instead we walk the system-wide process list with `CreateToolhelp32Snapshot`.
+This is the same mechanism `tasklist` and Process Explorer use; it returns
+native pids and parent pids, which is what `procIndexToDescs` needs to
+walk the descendant tree.
+*/
+func SubPids(_ int, _ bool) ([]int, error) {
+	return SubPidsViaSnapshot(os.Getpid())
+}
+
+func SubPidsViaSnapshot(topPid int) ([]int, error) {
+	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, gg.Wrap(err, `failed to create process snapshot`)
+	}
+	defer windows.CloseHandle(snap)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	err = windows.Process32First(snap, &entry)
+	if err != nil {
+		return nil, gg.Wrap(err, `failed to read first process from snapshot`)
+	}
+
+	ppidToPids := map[int][]int{}
+	for {
+		ppidToPids[int(entry.ParentProcessID)] = append(
+			ppidToPids[int(entry.ParentProcessID)], int(entry.ProcessID),
+		)
+		err = windows.Process32Next(snap, &entry)
+		if err != nil {
+			// `ERROR_NO_MORE_FILES` ends iteration; any other error is fatal.
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return nil, gg.Wrap(err, `failed to advance process snapshot`)
+		}
+	}
+
+	return procIndexToDescs(ppidToPids, topPid, 0), nil
+}

--- a/gow_signal_unix.go
+++ b/gow_signal_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	KILL_SIGS = []syscall.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM}
+	sigQuit   = syscall.SIGQUIT
+)
+
+func signalProc(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
+}
+
+func signalSelf(sig syscall.Signal) error {
+	return syscall.Kill(os.Getpid(), sig)
+}

--- a/gow_signal_windows.go
+++ b/gow_signal_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+/*
+Windows lacks SIGHUP and SIGQUIT. We register only SIGINT and SIGTERM, which
+are the signals that `signal.Notify` can actually deliver on Windows: SIGINT
+is raised by Ctrl-C in the console, and SIGTERM is delivered when an external
+process politely asks us to exit.
+*/
+var (
+	KILL_SIGS = []syscall.Signal{syscall.SIGINT, syscall.SIGTERM}
+
+	/*
+		The ^\ hotkey would normally raise SIGQUIT. Windows has no equivalent,
+		so we map it to SIGTERM, which behaves the same way for our purposes:
+		the broadcast handler will terminate descendant processes.
+	*/
+	sigQuit = syscall.SIGTERM
+)
+
+/*
+Windows has no `kill` syscall. We use `os.Process.Kill`, which calls
+`TerminateProcess`. This is unconditional and immediate: graceful signals
+like SIGTERM cannot be delivered to another process on Windows. From the
+caller's perspective the descendant process disappears, which is the
+behavior we need for restart and shutdown.
+*/
+func signalProc(pid int, _ syscall.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}
+
+/*
+On Unix this re-raises the signal so the runtime exits with the conventional
+`128 + signal` status. On Windows this distinction does not exist; the
+deferred `Main.Exit` will call `os.Exit(0)` in the normal shutdown path.
+*/
+func signalSelf(_ syscall.Signal) error { return nil }

--- a/gow_stdio.go
+++ b/gow_stdio.go
@@ -103,7 +103,7 @@ func (self *Stdio) OnCodeInterrupt() {
 }
 
 func (self *Stdio) OnCodeQuit() {
-	self.OnCodeSig(CODE_QUIT, syscall.SIGQUIT, `^\`)
+	self.OnCodeSig(CODE_QUIT, sigQuit, `^\`)
 }
 
 // TODO include all current subproces with their args.

--- a/gow_term.go
+++ b/gow_term.go
@@ -1,39 +1,15 @@
+//go:build !windows
+
 package main
 
 import (
+	"syscall"
+
 	"github.com/mitranim/gg"
 	"golang.org/x/sys/unix"
 )
 
-// https://en.wikipedia.org/wiki/ANSI_escape_code
-const (
-	// Standard terminal escape sequence. Same as "\x1b" or "\033".
-	TermEsc = string(rune(27))
-
-	// Control Sequence Introducer. Used for other codes.
-	TermEscCsi = TermEsc + `[`
-
-	// Update cursor position to first row, first column.
-	TermEscCup = TermEscCsi + `1;1H`
-
-	// Supposed to clear the screen without clearing the scrollback, aka soft
-	// clear. Seems insufficient on its own, at least in some terminals.
-	TermEscErase2 = TermEscCsi + `2J`
-
-	// Supposed to clear the screen and the scrollback, aka hard clear. Seems
-	// insufficient on its own, at least in some terminals.
-	TermEscErase3 = TermEscCsi + `3J`
-
-	// Supposed to reset the terminal to initial state, aka super hard clear.
-	// Seems insufficient on its own, at least in some terminals.
-	TermEscReset = TermEsc + `c`
-
-	// Clear screen without clearing scrollback.
-	TermEscClearSoft = TermEscCup + TermEscErase2
-
-	// Clear screen AND scrollback.
-	TermEscClearHard = TermEscCup + TermEscReset + TermEscErase3
-)
+var FD_TERM = syscall.Stdin
 
 /*
 By default, any TTY uses what's known as "cooked mode", where it buffers lines

--- a/gow_term_windows.go
+++ b/gow_term_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"github.com/mitranim/gg"
+	"golang.org/x/term"
+)
+
+/*
+Windows has no termios. We use `golang.org/x/term`, which configures the
+console via `SetConsoleMode` under the hood: `term.MakeRaw` clears
+`ENABLE_LINE_INPUT`, `ENABLE_ECHO_INPUT`, and `ENABLE_PROCESSED_INPUT`,
+giving us the same byte-at-a-time stdin behavior we get from termios raw
+mode on Unix.
+
+The trade-off compared to the Unix path: `term.MakeRaw` always disables
+echo, so `EchoModePreserve` is not honored on Windows. `EchoModeNone` and
+`EchoModeGow` (the default) work as designed.
+*/
+type Term struct{ State *term.State }
+
+func (self Term) IsActive() bool { return self.State != nil }
+
+func (self *Term) Deinit() {
+	state := self.State
+	if state == nil {
+		return
+	}
+	self.State = nil
+	gg.Nop1(term.Restore(int(os.Stdin.Fd()), state))
+}
+
+func (self *Term) Init(main *Main) {
+	self.Deinit()
+	if !main.Opt.Raw {
+		return
+	}
+
+	prev, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		log.Println(`unable to switch terminal to raw mode:`, err)
+		return
+	}
+
+	if main.Opt.Echo == EchoModePreserve && main.Opt.Verb {
+		log.Println(`echo mode "preserve" is not supported on Windows; echo will be disabled`)
+	}
+
+	self.State = prev
+}


### PR DESCRIPTION
Closes #6.

`gow` currently fails to compile on Windows because of direct dependencies on termios, `syscall.Kill`, `SIGHUP`, and `SIGQUIT`. This PR splits the Unix-only code paths behind build tags and adds Windows implementations of the two pieces that need real platform-specific code.

## Summary

- **Terminal raw mode** — new `gow_term_windows.go` uses `golang.org/x/term` (`MakeRaw` / `Restore`), which configures the console via `SetConsoleMode` and gives us the same byte-at-a-time stdin behavior as termios raw mode on Unix. The Unix `gow_term.go` is unchanged behind a `!windows` build tag.
  - Trade-off: `term.MakeRaw` always disables echo, so `EchoModePreserve` is not honored on Windows. `EchoModeNone` and `EchoModeGow` (the default) work as designed; the verbose log mentions when preserve was requested.
- **Descendant-pid enumeration** — new `gow_ps_windows.go` uses `CreateToolhelp32Snapshot` from `golang.org/x/sys/windows`. The Git Bash `ps` binary was deliberately not used: it reports MSYS pids that don't match `os.Getpid` / `exec.Cmd.Process.Pid`, so the existing `SubPidsViaPs` fallback would never find any descendants.
- **Signal handling** — `KILL_SIGS`, `sigQuit`, `signalProc`, `signalSelf` moved into `gow_signal_{unix,windows}.go`.
  - Windows lacks `SIGHUP` and `SIGQUIT`, so `KILL_SIGS` registers only `SIGINT` and `SIGTERM` (the signals `signal.Notify` can actually deliver on Windows).
  - `signalProc` calls `os.Process.Kill` (`TerminateProcess`) since there is no `kill` syscall on Windows; this is unconditional and immediate.
  - `^\` maps to `SIGTERM` on Windows; the broadcast handler still terminates descendants.
  - `signalSelf` is a no-op on Windows; the deferred `Main.Exit` calls `os.Exit(0)` in the normal shutdown path, so we don't need the Unix trick of re-raising the signal for a `128 + signal` exit code.
- Build tags on `gow_term.go`, `gow_const_linux.go`, and `gow_ps_bsd.go` updated to exclude `windows`.
- `TermEsc*` ANSI constants moved from `gow_term.go` to `gow_misc.go` since they are platform-independent strings.

No changes to existing Unix behavior — all Unix-only files compile and run identically.

## Test plan

- [x] `go build ./...` on `windows`, `linux`, `darwin`, `freebsd`
- [x] `go vet ./...` clean
- [x] `go test ./...` — 4/4 pass on Windows
- [x] End-to-end smoke test under Git Bash on Windows: `gow -v run .` against a minimal program; edited the file, observed the `notify` FS event, child process terminated, second run printed the updated output.
- [x] Hotkey testing in a ConPTY terminal (Windows Terminal): `^R` restart, `^T` / `^C` / `^\` single-press broadcast and double-press shutdown, `^H` help — all behave as documented.